### PR TITLE
Re-add compatibility with python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Records breaking changes from major version bumps
 
+## 25.3.1
+
+Some of our scripts run the native Jenkins version of Python which is v3.8 so we need to re-allow python v3.8 in the API client (which is used by scripts) 
+
 ## 25.3.0
 
 Add the API client methods for the conversation messages routes

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '25.3.0'
+__version__ = '25.3.1'
 
 from .errors import APIError, HTTPError, InvalidResponse  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
     install_requires=[
         'requests<3,>=2.18.4',
     ],
-    python_requires=">=3.9,<3.12",
+    python_requires=">=3.8,<3.12",
 )


### PR DESCRIPTION
Some of our scripts run the native Jenkins version of Python which is v3.8 so we need to re-allow python v3.8 in the API client (which is used by scripts)