### PR TITLE
NDMP-1494 Update evaluator locks so they are on the question level rather than the lot level

### DIFF
--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '35.0.1'
+__version__ = '35.0.2'
 
 from .errors import APIError, HTTPError, InvalidResponse, InvalidResponseType  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/audit.py
+++ b/dmapiclient/audit.py
@@ -118,6 +118,7 @@ class AuditTypes(Enum):
     update_evaluator_framework_lot_assignment_status = "update_evaluator_framework_lot_assignment_status"
     create_evaluator_framework_lot = "create_evaluator_framework_lot"
     update_evaluator_framework_lot_status = "update_evaluator_framework_lot_status"
+    update_evaluator_framework_lot_section_status = "update_evaluator_framework_lot_section_status"
     create_evaluator_framework_lot_section = "create_evaluator_framework_lot_section"
     update_evaluator_framework_lot_section_assignment_status = \
         "update_evaluator_framework_lot_section_assignment_status"

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -2019,6 +2019,18 @@ class DataAPIClient(BaseAPIClient):
             params=params
         )
 
+    def update_evaluator_framework_lot_section_status(
+        self,
+        evaluator_framework_lot_section_id,
+        status,
+        user=None
+    ):
+        return self._post_with_updated_by(
+            f"/evaluations/evaluator-framework-lot-sections/{evaluator_framework_lot_section_id}/status/{status}",
+            data={},
+            user=user,
+        )
+
     def find_evaluator_framework_lot_section_evaluations(
         self,
         framework,

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -5123,6 +5123,25 @@ class TestEvaluatorFrameworkLotMethods(object):
         assert result == {"evaluatorFrameworkLotSections": "result"}
         assert rmock.called
 
+    def test_update_evaluator_framework_lot_section_status(self, data_client, rmock):
+        rmock.post(
+            "http://baseurl/evaluations/evaluator-framework-lot-sections/1234/status/locked",
+            json={"message": "done"},
+            status_code=200
+        )
+
+        result = data_client.update_evaluator_framework_lot_section_status(
+            1234,
+            'locked',
+            'user'
+        )
+
+        assert result == {'message': 'done'}
+        assert rmock.called
+        assert rmock.request_history[0].json() == {
+            'updated_by': 'user',
+        }
+
     def test_find_evaluator_framework_lot_section_evaluations(self, data_client, rmock):
         rmock.get(
             "http://baseurl/evaluations/evaluator-framework-lot-section-evaluations?"


### PR DESCRIPTION
### Merging `NDMP_1494_update_evaluator_locks_so_they_are_on_the_question_level_rather_than_the_lot_level` → main

- bump version
- added new methods