### PR TITLE
Add create_broadcast_compliance_communication to TasksAPIClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Records breaking changes from major version bumps
 
 ## Unreleased
 
-## 38.3.3
+## 38.4
 
 Add `create_broadcast_compliance_communication` to `TasksAPIClient`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Records breaking changes from major version bumps
 
 ## Unreleased
 
-## 38.4
+## 38.4.0
 
 Add `create_broadcast_compliance_communication` to `TasksAPIClient`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Records breaking changes from major version bumps
 
 ## Unreleased
 
+## 38.3.3
+
+Add `create_broadcast_compliance_communication` to `TasksAPIClient`
+
 ## 38.3.2
 
 Reduce the auth token expiry to make sure we refesh it before it expires

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '38.3.2'
+__version__ = '38.3.3'
 
 from .errors import APIError, HTTPError, InvalidResponse, InvalidResponseType  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '38.4'
+__version__ = '38.4.0'
 
 from .errors import APIError, HTTPError, InvalidResponse, InvalidResponseType  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '38.3.3'
+__version__ = '38.4'
 
 from .errors import APIError, HTTPError, InvalidResponse, InvalidResponseType  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/tasks.py
+++ b/dmapiclient/tasks.py
@@ -48,16 +48,18 @@ class TasksAPIClient(BaseAPIClient):
         send_to_all=False,
         user=None,
     ):
+        data = {
+            'category': category,
+            'subject': subject,
+            'message': message,
+            'attachments': attachments,
+            'broadcastMessageId': broadcast_message_id,
+            'supplierIds': supplier_ids,
+        }
+        if send_to_all:
+            data['sendToAll'] = send_to_all
         return self._post_with_updated_by(
             '/frameworks/{}/compliance-communications/broadcast'.format(framework_slug),
-            data={
-                'category': category,
-                'subject': subject,
-                'message': message,
-                'attachments': attachments,
-                'broadcastMessageId': broadcast_message_id,
-                'supplierIds': supplier_ids,
-                'sendToAll': send_to_all,
-            },
+            data=data,
             user=user,
         )

--- a/dmapiclient/tasks.py
+++ b/dmapiclient/tasks.py
@@ -45,7 +45,6 @@ class TasksAPIClient(BaseAPIClient):
         attachments,
         broadcast_message_id,
         supplier_ids,
-        sender_user_id=None,
         user=None,
     ):
         return self._post_with_updated_by(
@@ -57,7 +56,6 @@ class TasksAPIClient(BaseAPIClient):
                 'attachments': attachments,
                 'broadcastMessageId': broadcast_message_id,
                 'supplierIds': supplier_ids,
-                'senderUserId': sender_user_id,
             },
             user=user,
         )

--- a/dmapiclient/tasks.py
+++ b/dmapiclient/tasks.py
@@ -35,3 +35,27 @@ class TasksAPIClient(BaseAPIClient):
             },
             user=user,
         )
+
+    def create_broadcast_compliance_communication(
+        self,
+        framework_slug,
+        category,
+        subject,
+        message,
+        attachments,
+        broadcast_message_id,
+        supplier_ids,
+        user=None,
+    ):
+        return self._post_with_updated_by(
+            '/frameworks/{}/compliance-communications/broadcast'.format(framework_slug),
+            data={
+                'category': category,
+                'subject': subject,
+                'message': message,
+                'attachments': attachments,
+                'broadcastMessageId': broadcast_message_id,
+                'supplierIds': supplier_ids,
+            },
+            user=user,
+        )

--- a/dmapiclient/tasks.py
+++ b/dmapiclient/tasks.py
@@ -45,6 +45,7 @@ class TasksAPIClient(BaseAPIClient):
         attachments,
         broadcast_message_id,
         supplier_ids,
+        sender_user_id=None,
         user=None,
     ):
         return self._post_with_updated_by(
@@ -56,6 +57,7 @@ class TasksAPIClient(BaseAPIClient):
                 'attachments': attachments,
                 'broadcastMessageId': broadcast_message_id,
                 'supplierIds': supplier_ids,
+                'senderUserId': sender_user_id,
             },
             user=user,
         )

--- a/dmapiclient/tasks.py
+++ b/dmapiclient/tasks.py
@@ -45,6 +45,7 @@ class TasksAPIClient(BaseAPIClient):
         attachments,
         broadcast_message_id,
         supplier_ids,
+        send_to_all=False,
         user=None,
     ):
         return self._post_with_updated_by(
@@ -56,6 +57,7 @@ class TasksAPIClient(BaseAPIClient):
                 'attachments': attachments,
                 'broadcastMessageId': broadcast_message_id,
                 'supplierIds': supplier_ids,
+                'sendToAll': send_to_all,
             },
             user=user,
         )

--- a/tests/test_tasks_api_client.py
+++ b/tests/test_tasks_api_client.py
@@ -109,3 +109,95 @@ class TestNotificationsMethods(object):
             'notificationTemplateName': notification_template_name,
             'notificationTemplateId': notification_template_id,
         }
+
+
+class TestComplianceCommunicationsMethods(object):
+    def test_create_broadcast_compliance_communication_returns_result(self, tasks_client, rmock):
+        rmock.post(
+            'http://baseurl/frameworks/g-cloud-7/compliance-communications/broadcast',
+            json={'request_id': '999'},
+            status_code=200,
+        )
+
+        result = tasks_client.create_broadcast_compliance_communication(
+            'g-cloud-7',
+            category='security',
+            subject='Important update',
+            message='Please review the attached documents.',
+            attachments=['file1.pdf', 'file2.pdf'],
+            broadcast_message_id='msg-123',
+            supplier_ids=[1, 2, 3],
+            user='user',
+        )
+
+        assert result == {'request_id': '999'}
+        assert rmock.called
+
+    def test_create_broadcast_compliance_communication_sends_correct_payload(self, tasks_client, rmock):
+        rmock.post(
+            'http://baseurl/frameworks/g-cloud-7/compliance-communications/broadcast',
+            json={'request_id': '999'},
+            status_code=200,
+        )
+
+        tasks_client.create_broadcast_compliance_communication(
+            'g-cloud-7',
+            category='security',
+            subject='Important update',
+            message='Please review the attached documents.',
+            attachments=['file1.pdf', 'file2.pdf'],
+            broadcast_message_id='msg-123',
+            supplier_ids=[1, 2, 3],
+            user='user',
+        )
+
+        assert rmock.request_history[0].json() == {
+            'updated_by': 'user',
+            'category': 'security',
+            'subject': 'Important update',
+            'message': 'Please review the attached documents.',
+            'attachments': ['file1.pdf', 'file2.pdf'],
+            'broadcastMessageId': 'msg-123',
+            'supplierIds': [1, 2, 3],
+        }
+
+    def test_create_broadcast_compliance_communication_raises_value_error_if_no_user(self, tasks_client, rmock):
+        rmock.post(
+            'http://baseurl/frameworks/g-cloud-7/compliance-communications/broadcast',
+            json={'request_id': '999'},
+            status_code=200,
+        )
+
+        with pytest.raises(ValueError):
+            tasks_client.create_broadcast_compliance_communication(
+                'g-cloud-7',
+                category='security',
+                subject='Important update',
+                message='Please review the attached documents.',
+                attachments=['file1.pdf', 'file2.pdf'],
+                broadcast_message_id='msg-123',
+                supplier_ids=[1, 2, 3],
+            )
+
+    def test_create_broadcast_compliance_communication_with_user_passed_per_call(self, rmock):
+        tasks_client = TasksAPIClient('http://baseurl', 'auth-token', enabled=True)
+
+        rmock.post(
+            'http://baseurl/frameworks/g-cloud-7/compliance-communications/broadcast',
+            json={'request_id': '999'},
+            status_code=200,
+        )
+
+        result = tasks_client.create_broadcast_compliance_communication(
+            'g-cloud-7',
+            category='security',
+            subject='Important update',
+            message='Please review the attached documents.',
+            attachments=['file1.pdf', 'file2.pdf'],
+            broadcast_message_id='msg-123',
+            supplier_ids=[1, 2, 3],
+            user='per-call-user@example.com',
+        )
+
+        assert result == {'request_id': '999'}
+        assert rmock.request_history[0].json()['updated_by'] == 'per-call-user@example.com'


### PR DESCRIPTION
## Add create_broadcast_compliance_communication to TasksAPIClient

[NDMP-1992](https://crowncommercialservice.atlassian.net/browse/NDMP-1992)

Adds a new `TasksAPIClient` method to trigger the broadcast compliance communication background job.

### Changes

- Adds `create_broadcast_compliance_communication` function to `dmapiclient/tasks.py`
- POSTs broadcast message

