### PR TITLE
Add decide_pending_service wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Records breaking changes from major version bumps
 
 ## Unreleased
 
+## 38.7.0
+
+Add `decide_pending_service` method for per-field approve/reject of supplier service edits
+
 ## 38.6.0
 
 Add task api client to send compliance communications notifications

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '38.7.0'
+__version__ = '38.8.0'
 
 from .errors import APIError, HTTPError, InvalidResponse, InvalidResponseType  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '38.6.0'
+__version__ = '38.7.0'
 
 from .errors import APIError, HTTPError, InvalidResponse, InvalidResponseType  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/data.py
+++ b/dmapiclient/data.py
@@ -1010,6 +1010,15 @@ class DataAPIClient(BaseAPIClient):
             user=user,
         )
 
+    def decide_pending_service(self, service_id, decisions, user=None):
+        return self._post_with_updated_by(
+            f'/pending-services/{service_id}/decisions',
+            data={
+                'decisions': decisions,
+            },
+            user=user,
+        )
+
     def update_service_status(self, service_id, status, user=None, *, wait_for_index: bool = True):
         return self._post_with_updated_by(
             '/services/{}/status/{}{}'.format(

--- a/tests/test_data_api_client.py
+++ b/tests/test_data_api_client.py
@@ -194,6 +194,26 @@ class TestServiceMethods(object):
         assert rmock.called
         assert rmock.last_request.json() == {'reasonText': 'reason_text', 'updated_by': 'testuser@example.com'}
 
+    def test_decide_pending_service(self, data_client, rmock):
+        rmock.post(
+            'http://baseurl/pending-services/123/decisions',
+            json={'message': 'done'},
+            status_code=200,
+        )
+
+        decisions = [
+            {'field': 'serviceName', 'action': 'approve'},
+            {'field': 'serviceSummary', 'action': 'reject', 'reasonText': 'unclear'},
+        ]
+        result = data_client.decide_pending_service(123, decisions, 'testuser@example.com')
+
+        assert result == {'message': 'done'}
+        assert rmock.called
+        assert rmock.last_request.json() == {
+            'decisions': decisions,
+            'updated_by': 'testuser@example.com',
+        }
+
     @pytest.mark.parametrize(
         'wait_for_index_call_arg,wait_for_index_req_arg',
         (


### PR DESCRIPTION
[NDMP-2276](https://crowncommercialservice.atlassian.net/browse/NDMP-2276)

### Summary
- Adds `decide_pending_service(service_id, decisions, user)` wrapper for the new `/pending-services/<id>/decisions` endpoint.
- Bumps version to **38.7.0**, updates `CHANGELOG.md`.