### PR TITLE
NDMP-2257 - Include country name and code in the `update_organisation_by_duns` in the Agreements Service API Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Records breaking changes from major version bumps
 
 ## Unreleased
 
+## 38.8.0
+
+Include country name and code in the `update_organisation_by_duns` in the Agreements Service API Client
+
 ## 38.7.1
 
 Remove `lot_slug` to `find_suppliers` method as it was not created correctly and so not useable

--- a/dmapiclient/__init__.py
+++ b/dmapiclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '38.7.1'
+__version__ = '38.8.0'
 
 from .errors import APIError, HTTPError, InvalidResponse, InvalidResponseType  # noqa
 from .errors import REQUEST_ERROR_STATUS_CODE, REQUEST_ERROR_MESSAGE  # noqa

--- a/dmapiclient/agreements_service.py
+++ b/dmapiclient/agreements_service.py
@@ -292,6 +292,8 @@ class AgreementsServiceAPIClient(BaseAPIClient):
         address_line_1=None,
         town_or_city=None,
         postcode=None,
+        country_code=None,
+        country_name=None,
     ):
         data = {}
 
@@ -309,6 +311,10 @@ class AgreementsServiceAPIClient(BaseAPIClient):
             data['locality'] = town_or_city
         if postcode is not None:
             data['postalCode'] = postcode
+        if country_code is not None:
+            data['countryCode'] = country_code
+        if country_name is not None:
+            data['countryName'] = country_name
 
         return self._patch(
             AgreementsServiceURL.UPDATE_ORGANISATION_BY_DUNS,

--- a/tests/test_agreements_service_client.py
+++ b/tests/test_agreements_service_client.py
@@ -469,6 +469,28 @@ class TestOrganisations(BaseTestAgreementsServiceAPIClient):
             'postalCode': 'M1 1AA',
         }
 
+    def test_update_organisation_by_duns_country_code(self, agreements_service_client, rmock):
+        self._patch_response_mock(rmock, '/duns/123456789')
+
+        result = agreements_service_client.update_organisation_by_duns('123456789', country_code='NP')
+
+        assert result == b''
+        assert rmock.called
+        assert rmock.request_history[1].json() == {
+            'countryCode': 'NP',
+        }
+
+    def test_update_organisation_by_duns_country_name(self, agreements_service_client, rmock):
+        self._patch_response_mock(rmock, '/duns/123456789')
+
+        result = agreements_service_client.update_organisation_by_duns('123456789', country_name='Japan')
+
+        assert result == b''
+        assert rmock.called
+        assert rmock.request_history[1].json() == {
+            'countryName': 'Japan',
+        }
+
     def test_update_organisation_by_duns_all_attributes(self, agreements_service_client, rmock):
         self._patch_response_mock(rmock, '/duns/123456789')
 
@@ -481,6 +503,8 @@ class TestOrganisations(BaseTestAgreementsServiceAPIClient):
             address_line_1='1 UA High Street',
             town_or_city='Musutafu',
             postcode='M1 1AA',
+            country_code='NP',
+            country_name='Japan',
         )
 
         assert result == b''
@@ -493,4 +517,6 @@ class TestOrganisations(BaseTestAgreementsServiceAPIClient):
             'streetAddress': '1 UA High Street',
             'locality': 'Musutafu',
             'postalCode': 'M1 1AA',
+            'countryCode': 'NP',
+            'countryName': 'Japan',
         }


### PR DESCRIPTION
Ticket: [NDMP-2257](https://crowncommercialservice.atlassian.net/browse/NDMP-2257)